### PR TITLE
[CHK-1697] (feat): update iban debt position

### DIFF
--- a/src/main/kotlin/it/pagopa/aca/services/AcaService.kt
+++ b/src/main/kotlin/it/pagopa/aca/services/AcaService.kt
@@ -56,6 +56,7 @@ class AcaService(
                                 debitPosition,
                                 newDebtPositionRequestDto,
                                 iupd,
+                                it.first,
                                 it.second
                             )
                         }

--- a/src/main/kotlin/it/pagopa/aca/utils/AcaUtils.kt
+++ b/src/main/kotlin/it/pagopa/aca/utils/AcaUtils.kt
@@ -68,6 +68,7 @@ class AcaUtils {
         oldDebitPosition: PaymentPositionModelBaseResponseDto,
         newDebtPositionRequestDto: NewDebtPositionRequestDto,
         iupd: Iupd,
+        iban: String,
         companyName: String?
     ): PaymentPositionModelDto {
         return PaymentPositionModelDto()
@@ -102,7 +103,7 @@ class AcaUtils {
                                             .organizationFiscalCode(iupd.fiscalCode)
                                             .idTransfer(TransferModelDto.IdTransferEnum._1)
                                             .category(transfer.category)
-                                            .iban(transfer.iban)
+                                            .iban(iban)
                                     }
                                     ?.toList()
                             )

--- a/src/test/kotlin/it/pagopa/aca/service/AcaServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/aca/service/AcaServiceTests.kt
@@ -35,6 +35,7 @@ class AcaServiceTests {
         private const val iuv = "302001069073736640"
         val iupd = Iupd(paFiscalCode, iuv)
         const val ibanTest = "IT55555555555555"
+        const val ibanTestUpdate = "IT66666666666666"
         const val companyName = "companyNameTests"
     }
     @Test
@@ -151,7 +152,7 @@ class AcaServiceTests {
         val responseCreate = AcaTestUtils.debitPositionModelResponse(iupd)
         /* preconditions */
         given(gpdClient.getDebtPosition(any(), any())).willReturn(Mono.just(responseGetPosition))
-        given(ibansClient.getIban(any(), any())).willReturn(Mono.just(Pair(ibanTest, companyName)))
+        given(ibansClient.getIban(any(), any())).willReturn(Mono.just(Pair(ibanTestUpdate, companyName)))
         given(gpdClient.updateDebtPosition(any(), any(), any()))
             .willReturn(Mono.just(responseCreate))
         /* tests */
@@ -168,6 +169,7 @@ class AcaServiceTests {
                     responseGetPosition,
                     requestCreatePosition,
                     iupd,
+                    ibanTestUpdate,
                     companyName
                 )
             )

--- a/src/test/kotlin/it/pagopa/aca/service/AcaServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/aca/service/AcaServiceTests.kt
@@ -152,7 +152,8 @@ class AcaServiceTests {
         val responseCreate = AcaTestUtils.debitPositionModelResponse(iupd)
         /* preconditions */
         given(gpdClient.getDebtPosition(any(), any())).willReturn(Mono.just(responseGetPosition))
-        given(ibansClient.getIban(any(), any())).willReturn(Mono.just(Pair(ibanTestUpdate, companyName)))
+        given(ibansClient.getIban(any(), any()))
+            .willReturn(Mono.just(Pair(ibanTestUpdate, companyName)))
         given(gpdClient.updateDebtPosition(any(), any(), any()))
             .willReturn(Mono.just(responseCreate))
         /* tests */

--- a/src/test/kotlin/it/pagopa/aca/service/AcaServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/aca/service/AcaServiceTests.kt
@@ -9,6 +9,7 @@ import it.pagopa.aca.exceptions.RestApiException
 import it.pagopa.aca.services.AcaService
 import it.pagopa.aca.utils.AcaUtils
 import it.pagopa.generated.gpd.model.PaymentPositionModelBaseResponseDto
+import it.pagopa.generated.gpd.model.PaymentPositionModelDto
 import java.util.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -16,6 +17,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
 import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
@@ -38,6 +41,8 @@ class AcaServiceTests {
         const val ibanTestUpdate = "IT66666666666666"
         const val companyName = "companyNameTests"
     }
+    @Captor
+    private lateinit var paymentPositionModelDtoCaptor: ArgumentCaptor<PaymentPositionModelDto>
     @Test
     fun `create position successfully`() = runTest {
         val requestCreatePosition = AcaTestUtils.createPositionRequestBody(iupd, 10)
@@ -154,10 +159,11 @@ class AcaServiceTests {
         given(gpdClient.getDebtPosition(any(), any())).willReturn(Mono.just(responseGetPosition))
         given(ibansClient.getIban(any(), any()))
             .willReturn(Mono.just(Pair(ibanTestUpdate, companyName)))
-        given(gpdClient.updateDebtPosition(any(), any(), any()))
+        given(gpdClient.updateDebtPosition(any(), any(), paymentPositionModelDtoCaptor.capture()))
             .willReturn(Mono.just(responseCreate))
         /* tests */
         acaService.handleDebitPosition(requestCreatePosition)
+        System.out.println(paymentPositionModelDtoCaptor.value.paymentOption?.get(0)?.transfer?.get(0)?.iban)
         /* Asserts */
         verify(gpdClient, Mockito.times(1))
             .getDebtPosition(requestCreatePosition.paFiscalCode, iupd.value())

--- a/src/test/kotlin/it/pagopa/aca/utils/AcaUtilsTests.kt
+++ b/src/test/kotlin/it/pagopa/aca/utils/AcaUtilsTests.kt
@@ -97,7 +97,10 @@ class AcaUtilsTests {
                 creditorInstitutionCode
             )
         Assertions.assertEquals(iupd.value(), objectUpdated.iupd)
-        Assertions.assertEquals(ibanUpdated, objectUpdated.paymentOption?.get(0)?.transfer?.get(0)?.iban)
+        Assertions.assertEquals(
+            ibanUpdated,
+            objectUpdated.paymentOption?.get(0)?.transfer?.get(0)?.iban
+        )
         Assertions.assertEquals(null, objectUpdated.validityDate)
         Assertions.assertEquals(apiRequestBody.entityType.value, objectUpdated.type.value)
     }

--- a/src/test/kotlin/it/pagopa/aca/utils/AcaUtilsTests.kt
+++ b/src/test/kotlin/it/pagopa/aca/utils/AcaUtilsTests.kt
@@ -79,6 +79,7 @@ class AcaUtilsTests {
 
     @Test
     fun `update old debit position successfully`() = runTest {
+        val ibanUpdated = "ITRU0123456789"
         val responseGetPosition =
             AcaTestUtils.responseGetPosition(
                 iupd,
@@ -92,9 +93,11 @@ class AcaUtilsTests {
                 responseGetPosition,
                 apiRequestBody,
                 iupd,
+                ibanUpdated,
                 creditorInstitutionCode
             )
         Assertions.assertEquals(iupd.value(), objectUpdated.iupd)
+        Assertions.assertEquals(ibanUpdated, objectUpdated.paymentOption?.get(0)?.transfer?.get(0)?.iban)
         Assertions.assertEquals(null, objectUpdated.validityDate)
         Assertions.assertEquals(apiRequestBody.entityType.value, objectUpdated.type.value)
     }


### PR DESCRIPTION
Update debt position iban in debt position update api

#### List of Changes

In update branch workflow add the iban update to the debt position.
Iban is retrieved from APIConf (named ibanClient in the code) and passed to the unique transfer of the debt position

#### Motivation and Context

This PR address a docs requirement about the update of debt position. When we invoke apiConfig to get company name, we need to use also company iban and update it in the transfer list item in payment option model.

#### How Has This Been Tested?

Junit test has been ran 

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
