### PR TITLE
[PAGOPA-2059] feat: Add check seg_codes authorization

### DIFF
--- a/api-spec/aca-api.yaml
+++ b/api-spec/aca-api.yaml
@@ -14,6 +14,13 @@ tags:
 paths:
   /paCreatePosition:
     post:
+      parameters:
+        - in: query
+          name: segregationCodes
+          required: false
+          schema:
+            type: string
+          description: Segregation codes for which broker is authorized
       tags:
         - ACA
       operationId: newDebtPosition

--- a/src/main/kotlin/it/pagopa/aca/client/IbansClient.kt
+++ b/src/main/kotlin/it/pagopa/aca/client/IbansClient.kt
@@ -26,9 +26,11 @@ class IbansClient(@Autowired @Qualifier("ibansApiClient") private val client: Ib
                 logger.info(
                     "Querying api config to retrieve iban for creditorInstitutionCode: $creditorInstitutionCode, request id: $requestId"
                 )
-                client.getCreditorInstitutionsIbansEnhanced(
+                client.getIbans(
+                    0,
                     creditorInstitutionCode,
                     requestId,
+                    5,
                     CREDITOR_INSTITUTION_LABEL
                 )
             } catch (e: WebClientResponseException) {

--- a/src/main/kotlin/it/pagopa/aca/client/IbansClient.kt
+++ b/src/main/kotlin/it/pagopa/aca/client/IbansClient.kt
@@ -20,17 +20,22 @@ class IbansClient(@Autowired @Qualifier("ibansApiClient") private val client: Ib
         const val CREDITOR_INSTITUTION_LABEL = "ACA"
     }
 
-    fun getIban(creditorInstitutionCode: String, requestId: String): Mono<Pair<String, String?>> {
+    fun getIban(
+        page: Int,
+        limit: Int,
+        creditorInstitutionCode: String,
+        requestId: String
+    ): Mono<Pair<String, String?>> {
         val response: Mono<IbansEnhancedDto> =
             try {
                 logger.info(
                     "Querying api config to retrieve iban for creditorInstitutionCode: $creditorInstitutionCode, request id: $requestId"
                 )
                 client.getIbans(
-                    0,
+                    page,
                     creditorInstitutionCode,
                     requestId,
-                    5,
+                    limit,
                     CREDITOR_INSTITUTION_LABEL
                 )
             } catch (e: WebClientResponseException) {

--- a/src/main/kotlin/it/pagopa/aca/client/IbansClient.kt
+++ b/src/main/kotlin/it/pagopa/aca/client/IbansClient.kt
@@ -29,7 +29,7 @@ class IbansClient(@Autowired @Qualifier("ibansApiClient") private val client: Ib
         val response: Mono<IbansEnhancedDto> =
             try {
                 logger.info(
-                    "Querying api config to retrieve iban for creditorInstitutionCode: $creditorInstitutionCode, request id: $requestId"
+                    "Querying api config to retrieve iban for creditorInstitutionCode: $creditorInstitutionCode, request id: $requestId, page $page, limit $limit"
                 )
                 client.getIbans(
                     page,

--- a/src/main/kotlin/it/pagopa/aca/controllers/AcaController.kt
+++ b/src/main/kotlin/it/pagopa/aca/controllers/AcaController.kt
@@ -46,7 +46,7 @@ class AcaController(private val webClient: WebClient = WebClient.create()) : PaC
 
     // Fun to check authorization based on IUV prefix
     private fun checkAuth(segregationCodes: String?, iuv: String): Boolean {
-        return segregationCodes?.contains(iuv.substring(0, 2)) == true
+        return (segregationCodes.isNullOrEmpty() || segregationCodes.contains(iuv.substring(0, 2)))
     }
 
     /** Controller warm up function, used to send a POST pa create position request */

--- a/src/main/kotlin/it/pagopa/aca/controllers/AcaController.kt
+++ b/src/main/kotlin/it/pagopa/aca/controllers/AcaController.kt
@@ -26,7 +26,8 @@ class AcaController(private val webClient: WebClient = WebClient.create()) : PaC
     private val logger = LoggerFactory.getLogger(this.javaClass)
 
     override suspend fun newDebtPosition(
-        newDebtPositionRequestDto: NewDebtPositionRequestDto
+        newDebtPositionRequestDto: NewDebtPositionRequestDto,
+        segregationCodes: kotlin.String?
     ): ResponseEntity<DebtPositionResponseDto> {
         logger.info("[ACA service] paCreatePosition")
         // Check authorization

--- a/src/main/kotlin/it/pagopa/aca/controllers/AcaController.kt
+++ b/src/main/kotlin/it/pagopa/aca/controllers/AcaController.kt
@@ -10,6 +10,7 @@ import java.time.Duration
 import java.time.temporal.ChronoUnit
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.reactive.function.client.WebClient
@@ -21,11 +22,21 @@ class AcaController(private val webClient: WebClient = WebClient.create()) : PaC
     private val logger = LoggerFactory.getLogger(this.javaClass)
 
     override suspend fun newDebtPosition(
-        newDebtPositionRequestDto: NewDebtPositionRequestDto
+        newDebtPositionRequestDto: NewDebtPositionRequestDto,
+        segregationCodes: String?
     ): ResponseEntity<Unit> {
         logger.info("[ACA service] paCreatePosition")
+        // Check authorization
+        if (!checkAuth(segregationCodes, newDebtPositionRequestDto.iuv))
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        // Handle request
         acaService.handleDebitPosition(newDebtPositionRequestDto)
         return ResponseEntity.ok().build()
+    }
+
+    // Fun to check authorization based on IUV prefix
+    private fun checkAuth(segregationCodes: String?, iuv: String): Boolean {
+        return segregationCodes?.contains(iuv.substring(0, 2)) == true
     }
 
     /** Controller warm up function, used to send a POST pa create position request */

--- a/src/main/kotlin/it/pagopa/aca/services/AcaService.kt
+++ b/src/main/kotlin/it/pagopa/aca/services/AcaService.kt
@@ -54,7 +54,7 @@ class AcaService(
                     if (newDebtPositionRequestDto.iban == null) {
                         logger.info("Update debit position with iupd: ${iupd.value()}")
                         ibansClient
-                            .getIban(paFiscalCode, requestId)
+                            .getIban(0, 1, paFiscalCode, requestId) // only the first iban is used
                             .map {
                                 acaUtils.updateOldDebitPositionObject(
                                     debitPosition,
@@ -101,7 +101,7 @@ class AcaService(
                 } else {
                     if (newDebtPositionRequestDto.iban == null) {
                         ibansClient
-                            .getIban(paFiscalCode, requestId)
+                            .getIban(0, 1, paFiscalCode, requestId) // only the first iban is used
                             .map { response ->
                                 acaUtils.toPaymentPositionModelDto(
                                     newDebtPositionRequestDto,

--- a/src/test/kotlin/it/pagopa/aca/client/IbansClientTest.kt
+++ b/src/test/kotlin/it/pagopa/aca/client/IbansClientTest.kt
@@ -147,15 +147,7 @@ class IbansClientTest {
         val ibansApi = mock<IbansApi>()
         val ibansClient = IbansClient(ibansApi)
         val httpErrorStatusCode = HttpStatus.CONFLICT
-        given(
-                ibansApi.getIbans(
-                    0,
-                    creditorInstitutionCode,
-                    requestId,
-                    5,
-                    "ACA"
-                )
-            )
+        given(ibansApi.getIbans(0, creditorInstitutionCode, requestId, 5, "ACA"))
             .willThrow(
                 WebClientResponseException.create(
                     httpErrorStatusCode.value(),

--- a/src/test/kotlin/it/pagopa/aca/client/IbansClientTest.kt
+++ b/src/test/kotlin/it/pagopa/aca/client/IbansClientTest.kt
@@ -111,7 +111,8 @@ class IbansClientTest {
                 .addHeader("Content-Type", "application/json")
         )
         // test
-        val (iban, companyName) = ibansClient.getIban(creditorInstitutionCode, requestId).block()!!
+        val (iban, companyName) =
+            ibansClient.getIban(0, 1, creditorInstitutionCode, requestId).block()!!
         // assertions
         assertEquals(mockedResponse.ibansEnhanced[0].iban, iban)
         assertEquals(mockedResponse.ibansEnhanced[0].companyName, companyName)
@@ -132,7 +133,7 @@ class IbansClientTest {
                 .addHeader("Content-Type", "application/json")
         )
         // test
-        StepVerifier.create(ibansClient.getIban(creditorInstitutionCode, requestId))
+        StepVerifier.create(ibansClient.getIban(0, 1, creditorInstitutionCode, requestId))
             .expectErrorMatches {
                 it as ApiConfigException
                 it.toRestException().description == expectedDescription
@@ -147,7 +148,7 @@ class IbansClientTest {
         val ibansApi = mock<IbansApi>()
         val ibansClient = IbansClient(ibansApi)
         val httpErrorStatusCode = HttpStatus.CONFLICT
-        given(ibansApi.getIbans(0, creditorInstitutionCode, requestId, 5, "ACA"))
+        given(ibansApi.getIbans(0, creditorInstitutionCode, requestId, 1, "ACA"))
             .willThrow(
                 WebClientResponseException.create(
                     httpErrorStatusCode.value(),
@@ -158,7 +159,7 @@ class IbansClientTest {
                 )
             )
         // test
-        StepVerifier.create(ibansClient.getIban(creditorInstitutionCode, requestId))
+        StepVerifier.create(ibansClient.getIban(0, 1, creditorInstitutionCode, requestId))
             .expectErrorMatches {
                 it as ApiConfigException
                 it.toRestException().description == "Api config error: $httpErrorStatusCode"

--- a/src/test/kotlin/it/pagopa/aca/client/IbansClientTest.kt
+++ b/src/test/kotlin/it/pagopa/aca/client/IbansClientTest.kt
@@ -148,9 +148,11 @@ class IbansClientTest {
         val ibansClient = IbansClient(ibansApi)
         val httpErrorStatusCode = HttpStatus.CONFLICT
         given(
-                ibansApi.getCreditorInstitutionsIbansEnhanced(
+                ibansApi.getIbans(
+                    0,
                     creditorInstitutionCode,
                     requestId,
+                    5,
                     "ACA"
                 )
             )

--- a/src/test/kotlin/it/pagopa/aca/controller/AcaControllerTests.kt
+++ b/src/test/kotlin/it/pagopa/aca/controller/AcaControllerTests.kt
@@ -81,10 +81,7 @@ class AcaControllerTests {
         webClient
             .post()
             .uri { uriBuilder ->
-                uriBuilder
-                    .path("/paCreatePosition")
-                    .queryParam("segregationCodes", "97,98")
-                    .build()
+                uriBuilder.path("/paCreatePosition").queryParam("segregationCodes", "97,98").build()
             }
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(request)

--- a/src/test/kotlin/it/pagopa/aca/controller/AcaControllerTests.kt
+++ b/src/test/kotlin/it/pagopa/aca/controller/AcaControllerTests.kt
@@ -65,6 +65,35 @@ class AcaControllerTests {
     }
 
     @Test
+    fun `post paCreatePosition forbidden`() = runTest {
+        val request =
+            NewDebtPositionRequestDto(
+                iuv = "302001069073736640",
+                companyName = "company name",
+                entityType = NewDebtPositionRequestDto.EntityType.F,
+                entityFullName = "entity example full name",
+                entityFiscalCode = "RYGFHDDDYR7FDFTR",
+                description = "description test",
+                amount = 10,
+                expirationDate = OffsetDateTime.now(),
+                paFiscalCode = "77777777777"
+            )
+        webClient
+            .post()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path("/paCreatePosition")
+                    .queryParam("segregationCodes", "97,98")
+                    .build()
+            }
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @Test
     fun `warm up controller`() = runTest {
         val webClient = mock(WebClient::class.java)
         given(webClient.post()).willReturn(requestBodyUriSpec)

--- a/src/test/kotlin/it/pagopa/aca/service/AcaServiceTests.kt
+++ b/src/test/kotlin/it/pagopa/aca/service/AcaServiceTests.kt
@@ -48,7 +48,8 @@ class AcaServiceTests {
         /* preconditions */
         given(gpdClient.getDebtPosition(any(), any(), anyOrNull()))
             .willReturn(Mono.error(GpdPositionNotFoundException()))
-        given(ibansClient.getIban(any(), any())).willReturn(Mono.just(Pair(ibanTest, companyName)))
+        given(ibansClient.getIban(any(), any(), any(), any()))
+            .willReturn(Mono.just(Pair(ibanTest, companyName)))
         given(gpdClient.createDebtPosition(any(), any(), anyOrNull()))
             .willReturn(Mono.just(responseCreate))
         /* tests */
@@ -57,7 +58,7 @@ class AcaServiceTests {
         verify(gpdClient, Mockito.times(1))
             .getDebtPosition(requestCreatePosition.paFiscalCode, iupd.value())
         verify(ibansClient, Mockito.times(1))
-            .getIban(eq(requestCreatePosition.paFiscalCode), anyOrNull())
+            .getIban(any(), any(), eq(requestCreatePosition.paFiscalCode), anyOrNull())
         verify(gpdClient, Mockito.times(1))
             .createDebtPosition(
                 requestCreatePosition.paFiscalCode,
@@ -110,7 +111,7 @@ class AcaServiceTests {
         verify(gpdClient, Mockito.times(1))
             .getDebtPosition(requestCreatePosition.paFiscalCode, iupd.value())
         verify(gpdClient, Mockito.times(0)).createDebtPosition(any(), any(), anyOrNull())
-        verify(ibansClient, Mockito.times(0)).getIban(any(), any())
+        verify(ibansClient, Mockito.times(0)).getIban(any(), any(), any(), any())
     }
 
     @Test
@@ -133,7 +134,7 @@ class AcaServiceTests {
         verify(gpdClient, Mockito.times(1))
             .getDebtPosition(requestCreatePosition.paFiscalCode, iupd.value())
         verify(gpdClient, Mockito.times(0)).createDebtPosition(any(), any(), anyOrNull())
-        verify(ibansClient, Mockito.times(0)).getIban(any(), any())
+        verify(ibansClient, Mockito.times(0)).getIban(any(), any(), any(), any())
     }
 
     @Test
@@ -159,7 +160,7 @@ class AcaServiceTests {
             .getDebtPosition(requestCreatePosition.paFiscalCode, iupd.value())
         verify(gpdClient, Mockito.times(1))
             .invalidateDebtPosition(requestCreatePosition.paFiscalCode, iupd.value())
-        verify(ibansClient, Mockito.times(0)).getIban(any(), any())
+        verify(ibansClient, Mockito.times(0)).getIban(any(), any(), any(), any())
         verify(gpdClient, Mockito.times(0))
             .createDebtPosition(
                 requestCreatePosition.paFiscalCode,
@@ -186,7 +187,7 @@ class AcaServiceTests {
         /* preconditions */
         given(gpdClient.getDebtPosition(any(), any(), anyOrNull()))
             .willReturn(Mono.just(responseGetPosition))
-        given(ibansClient.getIban(any(), any()))
+        given(ibansClient.getIban(any(), any(), any(), any()))
             .willReturn(Mono.just(Pair(ibanTestUpdate, companyName)))
         given(
                 gpdClient.updateDebtPosition(
@@ -203,7 +204,7 @@ class AcaServiceTests {
         verify(gpdClient, Mockito.times(1))
             .getDebtPosition(requestCreatePosition.paFiscalCode, iupd.value())
         verify(ibansClient, Mockito.times(1))
-            .getIban(eq(requestCreatePosition.paFiscalCode), anyOrNull())
+            .getIban(any(), any(), eq(requestCreatePosition.paFiscalCode), anyOrNull())
         verify(gpdClient, Mockito.times(1))
             .updateDebtPosition(
                 requestCreatePosition.paFiscalCode,
@@ -246,7 +247,7 @@ class AcaServiceTests {
         /* preconditions */
         given(gpdClient.getDebtPosition(any(), any(), anyOrNull()))
             .willReturn(Mono.just(responseGetPosition))
-        given(ibansClient.getIban(any(), any()))
+        given(ibansClient.getIban(any(), any(), any(), any()))
             .willReturn(Mono.just(Pair(ibanTestUpdate, companyName)))
         given(
                 gpdClient.updateDebtPosition(
@@ -263,7 +264,7 @@ class AcaServiceTests {
         verify(gpdClient, Mockito.times(1))
             .getDebtPosition(requestCreatePosition.paFiscalCode, iupd.value())
         verify(ibansClient, Mockito.times(0))
-            .getIban(eq(requestCreatePosition.paFiscalCode), anyOrNull())
+            .getIban(any(), any(), eq(requestCreatePosition.paFiscalCode), anyOrNull())
         verify(gpdClient, Mockito.times(1))
             .updateDebtPosition(
                 requestCreatePosition.paFiscalCode,
@@ -301,7 +302,7 @@ class AcaServiceTests {
         /* preconditions */
         given(gpdClient.getDebtPosition(any(), any(), anyOrNull()))
             .willReturn(Mono.just(responseGetPosition))
-        given(ibansClient.getIban(any(), any()))
+        given(ibansClient.getIban(any(), any(), any(), any()))
             .willReturn(Mono.just(Pair(ibanTestUpdate, companyName)))
         given(
                 gpdClient.updateDebtPosition(
@@ -318,7 +319,7 @@ class AcaServiceTests {
         verify(gpdClient, Mockito.times(1))
             .getDebtPosition(requestCreatePosition.paFiscalCode, iupd.value())
         verify(ibansClient, Mockito.times(1))
-            .getIban(eq(requestCreatePosition.paFiscalCode), anyOrNull())
+            .getIban(any(), any(), eq(requestCreatePosition.paFiscalCode), anyOrNull())
         verify(gpdClient, Mockito.times(1))
             .updateDebtPosition(
                 requestCreatePosition.paFiscalCode,
@@ -350,7 +351,8 @@ class AcaServiceTests {
         /* preconditions */
         given(gpdClient.getDebtPosition(any(), any(), anyOrNull()))
             .willReturn(Mono.error(GpdPositionNotFoundException()))
-        given(ibansClient.getIban(any(), any())).willReturn(Mono.just(Pair(ibanTest, companyName)))
+        given(ibansClient.getIban(any(), any(), any(), any()))
+            .willReturn(Mono.just(Pair(ibanTest, companyName)))
         given(gpdClient.createDebtPosition(any(), any(), anyOrNull()))
             .willReturn(Mono.just(responseCreate))
         /* tests */
@@ -358,7 +360,7 @@ class AcaServiceTests {
         /* Asserts */
         verify(gpdClient, Mockito.times(1)).getDebtPosition(any(), any(), anyOrNull())
         verify(ibansClient, Mockito.times(0))
-            .getIban(eq(requestCreatePosition.paFiscalCode), anyOrNull())
+            .getIban(any(), any(), eq(requestCreatePosition.paFiscalCode), anyOrNull())
         verify(gpdClient, Mockito.times(1))
             .createDebtPosition(
                 requestCreatePosition.paFiscalCode,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Addition of the `checkAuth` function that checks if the user is authorized for the segregation code present in the IUV, checking that it is present in the query param `segregation codes`
- Update ACA openAPI (only for internal purposes) with optional query param `segregation codes` 

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

- Authorization by `segregation codes`

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- tested in DEV environment ✋ 

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
