### PR TITLE
[PIDM-37] fix:  Get iban with empty list response

### DIFF
--- a/src/main/kotlin/it/pagopa/aca/client/IbansClient.kt
+++ b/src/main/kotlin/it/pagopa/aca/client/IbansClient.kt
@@ -42,6 +42,15 @@ class IbansClient(@Autowired @Qualifier("ibansApiClient") private val client: Ib
                 Mono.error(e)
             }
         return response
+            .filter { it.ibansEnhanced.isNotEmpty() }
+            .switchIfEmpty(
+                Mono.error(
+                    ApiConfigException(
+                        description = "No iban found for creditor institution with code: $creditorInstitutionCode",
+                        httpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR
+                    )
+                )
+            )
             .map {
                 // TODO here we have to just take the first returned IbanDto object?
                 val ibanDto = it.ibansEnhanced[0]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- added check for empty iban list before retrieving iban for debt position

<!--- Describe your changes in detail -->

#### Motivation and Context
[PIDM-37](https://pagopa.atlassian.net/browse/PIDM-37)
Avoid indexOutOfBound exception when retrieving iban from getIban response
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[PIDM-37]: https://pagopa.atlassian.net/browse/PIDM-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ